### PR TITLE
Covering unsupported parameters in ansible examples.

### DIFF
--- a/examples/ansible/README.txt
+++ b/examples/ansible/README.txt
@@ -8,7 +8,7 @@ To install this module:
 1. Install Ansible (via a package manager).
 
 2. Install the "vdo.py" module file by copying it into the site-packages
-   subdirectory for Ansible, on place the file in ./library/.
+   subdirectory for Ansible, or place the file in ./library/.
 
    Example for RHEL 7.3:
    /usr/lib/python2.7/site-packages/ansible/modules/extras/system/vdo.py

--- a/examples/ansible/README.txt
+++ b/examples/ansible/README.txt
@@ -8,7 +8,7 @@ To install this module:
 1. Install Ansible (via a package manager).
 
 2. Install the "vdo.py" module file by copying it into the site-packages
-   subdirectory for Ansible.
+   subdirectory for Ansible, on place the file in ./library/.
 
    Example for RHEL 7.3:
    /usr/lib/python2.7/site-packages/ansible/modules/extras/system/vdo.py

--- a/examples/ansible/test_vdocreate.yml
+++ b/examples/ansible/test_vdocreate.yml
@@ -9,6 +9,5 @@
     vdo:
       name: vdo1
       state: present
-      volumegroup: VDO
-      physicalsize: 260G
       logicalsize: 1T
+      device: /dev/volumegroup/logicalvolume

--- a/examples/ansible/test_vdocreate_alloptions.yml
+++ b/examples/ansible/test_vdocreate_alloptions.yml
@@ -11,9 +11,8 @@
       state: present
       compression: enabled
       deduplication: enabled
-      volumegroup: VDO
-      physicalsize: 260G
       logicalsize: 1T
+      device: /dev/volumgroup/logicalvolume
       blockmapcachesize: 21G
       readcache: enabled
       readcachesize: 64M


### PR DESCRIPTION
All references to unsupported parameters have been updated, added mandatory "device". Also included a (readme.txt) trick to place the vdo.py module in ./library/