### PR TITLE
Fixing for old blkid versions 

### DIFF
--- a/utils/vdo/user/vdoformat.c
+++ b/utils/vdo/user/vdoformat.c
@@ -294,8 +294,12 @@ static int checkForSignaturesUsingBlkid(const char *filename, bool force)
 				    BLKID_SUBLKS_TYPE |
 				    BLKID_SUBLKS_USAGE |
 				    BLKID_SUBLKS_VERSION |
+#if defined (BLKID_SUBLKS_BADCSUM)
 				    BLKID_SUBLKS_MAGIC |
 				    BLKID_SUBLKS_BADCSUM);
+#else
+				    BLKID_SUBLKS_MAGIC );
+#endif
 
   Buffer *buffer = NULL;
   result = makeBuffer(0, &buffer);


### PR DESCRIPTION
Older versions (e.g. 2.23) of blkid header doesn't define the BLKID_SUBLKS_BADCSUM and this is a quick fix to at least get it building. 

There might be a better way to key off of the BLKID_VERSION but this is simple enough.

Signed-off-by: Muhammad Ahmad <muhammad.ahmad@seagate.com>