### PR TITLE
fix error support clang

### DIFF
--- a/utils/uds/Makefile
+++ b/utils/uds/Makefile
@@ -25,29 +25,6 @@ ifeq ($(origin CC), default)
   CC=gcc
 endif
 
-WARNS =	-Wall			\
-	-Wcast-align		\
-	-Werror			\
-	-Wextra			\
-	-Winit-self		\
-	-Wlogical-op		\
-	-Wmissing-include-dirs	\
-	-Wpointer-arith		\
-	-Wredundant-decls	\
-	-Wunused		\
-	-Wwrite-strings
-
-C_WARNS =	-Wbad-function-cast		\
-		-Wcast-qual			\
-		-Wfloat-equal			\
-		-Wformat=2			\
-		-Wmissing-declarations		\
-		-Wmissing-format-attribute	\
-		-Wmissing-prototypes		\
-		-Wnested-externs		\
-		-Wold-style-definition		\
-		-Wswitch-default
-
 OPT_FLAGS      = -O3 -fno-omit-frame-pointer
 DEBUG_FLAGS    =
 RPM_OPT_FLAGS ?= -fpic

--- a/utils/vdo/Makefile
+++ b/utils/vdo/Makefile
@@ -21,32 +21,6 @@ VDO_VERSION = 8.3.0.71
 
 UDS_DIR      = ../uds
 
-
-WARNS            =				\
-		   -Wall			\
-		   -Wcast-align			\
-		   -Werror			\
-		   -Wextra			\
-		   -Winit-self			\
-		   -Wlogical-op			\
-		   -Wmissing-include-dirs	\
-		   -Wpointer-arith		\
-		   -Wredundant-decls		\
-		   -Wunused			\
-		   -Wwrite-strings		\
-
-C_WARNS          =				\
-		   -Wbad-function-cast		\
-		   -Wcast-qual			\
-		   -Wfloat-equal		\
-		   -Wformat=2			\
-		   -Wmissing-declarations	\
-		   -Wmissing-format-attribute	\
-		   -Wmissing-prototypes		\
-		   -Wnested-externs		\
-		   -Wold-style-definition	\
-		   -Wswitch-default		\
-
 ifeq ($(AR), ar)
 	ifeq ($(origin AR), default)
 		AR := gcc-ar


### PR DESCRIPTION
I meet problems like this when I use clang:
[   89s] error: unknown warning option '-Wlogical-op'; did you mean '-Wlong-long'? [-Werror,-Wunknown-warning-option]
[   89s] make[2]: *** [Makefile:137: chapter-index.o] Error 1
[   89s] make[2]: Entering directory '/home/abuild/rpmbuild/BUILD/vdo-8.2.2.2/utils/uds'
[   89s] clang -O2 -g -grecord-gcc-switches -pipe -fstack-protector-strong  -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS --config /usr/lib/rpm/generic-hardened-clang.cfg -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection  -D_GNU_SOURCE -g -O3 -fno-omit-frame-pointer -Wall -Wcast-align -Werror -Wextra -Winit-self -Wlogical-op -Wmissing-include-dirs -Wpointer-arith -Wredundant-decls -Wunused -Wwrite-strings   -DCURRENT_VERSION='"8.2.2.2"'  -I. -std=gnu99 -pedantic -Wbad-function-cast -Wcast-qual -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-format-attribute -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wswitch-default    -c -MD -MF .deps/config.d.new -MP -MT config.o config.c -o config.o
[   89s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/vdo-8.2.2.2/utils/uds'
so i want to solve this problem